### PR TITLE
create_admin.py, fixed email log bug, added rua logo to header

### DIFF
--- a/src/core/fixtures/settings/master.json
+++ b/src/core/fixtures/settings/master.json
@@ -837,7 +837,7 @@
 },
 {
     "fields": {
-        "value": "1b9eb19e-ad8e-45e0-acdc-7c11d13da3df..png",
+        "value": null,
         "group": 4,
         "name": "brand_header",
         "types": "file",

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -1305,30 +1305,32 @@ def view_log(request, submission_id):
         query_list.append(Q(message__icontains=search) | Q(short_name__icontains=search) | Q(kind__icontains=search))
    
     if query_list:
-        log_list =  models.Log.objects.filter(Q(book=book) | Q(proposal=book.proposal)).filter(*query_list).order_by('-date_logged')
+        log_list =  models.Log.objects.filter(Q(book=book)).filter(*query_list).order_by('-date_logged')
     else:
-        log_list = models.Log.objects.filter(Q(book=book) | Q(proposal=book.proposal)).order_by('-date_logged')
+        log_list = models.Log.objects.filter(Q(book=book)).order_by('-date_logged')
 
     if email_query_list:
-        email_list =  models.EmailLog.objects.filter(Q(book=book) | Q(proposal=book.proposal)).filter(*email_query_list).order_by('-sent')
+        print email_query_list
+        email_list =  models.EmailLog.objects.filter(Q(book=book)).filter(*email_query_list).order_by('-sent')
     else:
-        email_list = models.EmailLog.objects.filter(Q(book=book) | Q(proposal=book.proposal)).order_by('-sent')
+        email_list = models.EmailLog.objects.filter(Q(book=book)).order_by('-sent')
+
 
     filters = [
-    'submission',
-    'workflow',
-    'file',
-    'copyedit',
-    'review',
-    'proposal_review',
-    'index',
-    'typeset',
-    'revisions',
-    'editing',
-    'production',
-    'proposal',
-    'general',
-    'reminder',
+        'submission',
+        'workflow',
+        'file',
+        'copyedit',
+        'review',
+        'proposal_review',
+        'index',
+        'typeset',
+        'revisions',
+        'editing',
+        'production',
+        'proposal',
+        'general',
+        'reminder',
     ]
 
     template = 'editor/log.html'

--- a/src/templates/nav.html
+++ b/src/templates/nav.html
@@ -3,7 +3,7 @@
             <div class="container">
               <div class="navbar-header">
                 <a class="navbar-brand" href="#">
-                  <img class="img-responsive" alt="Brand" src="{{ MEDIA_URL }}settings/{{ press.look.brand_header }}">
+                  {% if press.look.brand_header %}<img class="img-responsive" alt="Brand" src="{{ MEDIA_URL }}settings/{{ press.look.brand_header }}">{% else %}<img class="img-responsive" alt="Brand" src="{{ MEDIA_URL }}img/default_brand.png">{% endif %}
                 </a>
                 <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
                   <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
create_admin.py command added to run rua on local machine, to be added to general install tool. Bug that used to show emails for all books submitted by user rather than just one in question fixed by editing filters in log_view. RUA logo added as default header image.
