### PR TITLE
Add margin for footer

### DIFF
--- a/src/static-assets/css/over-rides.css
+++ b/src/static-assets/css/over-rides.css
@@ -1277,6 +1277,11 @@ body {
   padding: 0 0 60px;
 }
 
+/* Add margin to content to allow room for footer*/
+.content {
+  margin-bottom: 60px;
+}
+
 /* Set the fixed height of the footer here */
 .footer {
   margin-top: 10px;

--- a/src/static-assets/css/over-rides.css
+++ b/src/static-assets/css/over-rides.css
@@ -1294,6 +1294,7 @@ body {
     position: fixed;
     width: 100%;
     bottom: 0;
+    z-index: 5;
 }
 
 p.footer {

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -17,7 +17,7 @@
 
 	<body>
 	{% include "nav.html" %}
-	<div class="container">
+	<div class="container content">
 		{% block breadcrumbs %}
 		{% endblock %}
 		{% block body %}{% endblock body %}

--- a/src/templates/base_no_messages.html
+++ b/src/templates/base_no_messages.html
@@ -16,7 +16,7 @@
 
 	<body>
 	{% include "nav.html" %}
-	<div class="container">
+	<div class="container content">
 		{% block breadcrumbs %}
 		{% endblock %}
 

--- a/src/templates/base_no_nav.html
+++ b/src/templates/base_no_nav.html
@@ -17,7 +17,7 @@
 
 	<body>
 	
-	<div class="container">
+	<div class="container content">
 		{% block breadcrumbs %}
 		{% endblock %}
 		{% block body %}{% endblock body %}

--- a/src/templates/editor/published_books.html
+++ b/src/templates/editor/published_books.html
@@ -5,12 +5,7 @@
 {% block title %}Published Books{% endblock %}
 
 {% block css %}
- <style type="text/css">
-    body {
-        overflow:hidden;
-    } 
- </style>
-	<link href="{% static "css/timeline.css" %}" rel="stylesheet">
+<link href="{% static "css/timeline.css" %}" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/plug-ins/1.10.7/integration/bootstrap/3/dataTables.bootstrap.css">
 {% endblock %}
 

--- a/src/templates/fluid-base.html
+++ b/src/templates/fluid-base.html
@@ -16,7 +16,7 @@
 
 	<body>
 	{% include "nav.html" %}
-	<div class="container-fluid">
+	<div class="container-fluid content">
 		{% block breadcrumbs %}
 		{% endblock %}
 		{% block body %}{% endblock body %}


### PR DESCRIPTION
Made changes to prevent the version footer from obscuring page content, including

- Adding a margin to the main page content to allow room for the footer
- Removing `overflow='hidden'` property from a the published books page, since there isn't enough room on the screen for all content

Trello card: https://trello.com/c/CdbtAipj/2551-1-174-add-version-footer
