### PR TITLE
Addressing unicode bug in review request decision pages

### DIFF
--- a/src/review/views.py
+++ b/src/review/views.py
@@ -278,8 +278,8 @@ def reviewer_decision(
     if decision and decision == 'accept':
         review_assignment.accepted = timezone.now()
         message = (
-            "Review Assignment request for '{book_title}' has been accepted "
-            "by {first_name} {last_name}.".format(
+            u"Review Assignment request for '{book_title}' has been accepted "
+            u"by {first_name} {last_name}.".format(
                 book_title=submission.title,
                 first_name=review_assignment.user.first_name,
                 last_name=review_assignment.user.last_name,
@@ -296,8 +296,8 @@ def reviewer_decision(
     elif decision and decision == 'decline':
         review_assignment.declined = timezone.now()
         message = (
-            "Review Assignment request for '{book_title}' has been declined "
-            "by {reviewer_first_name} {reviewer_last_name}.".format(
+            u"Review Assignment request for '{book_title}' has been declined "
+            u"by {reviewer_first_name} {reviewer_last_name}.".format(
                 book_title=submission.title,
                 reviewer_first_name=review_assignment.user.first_name,
                 reviewer_last_name=review_assignment.user.last_name,
@@ -316,8 +316,8 @@ def reviewer_decision(
         if 'accept' in request.POST:
             review_assignment.accepted = timezone.now()
             message = (
-                "Review Assignment request for '{book_title} has been accepted'"
-                " by {first_name} {last_name}.".format(
+                u"Review Assignment request for '{book_title}' has been "
+                u"accepted by {first_name} {last_name}.".format(
                     book_title=submission.title,
                     first_name=review_assignment.user.first_name,
                     last_name=review_assignment.user.last_name,
@@ -334,8 +334,8 @@ def reviewer_decision(
         elif 'decline' in request.POST:
             review_assignment.declined = timezone.now()
             message = (
-                "Review Assignment request for '{book_title}' has been declined"
-                " by {first_name} {last_name}.".format(
+                u"Review Assignment request for '{book_title}' has been "
+                u"declined by {first_name} {last_name}.".format(
                     book_title=submission.title,
                     first_name=review_assignment.user.first_name,
                     last_name=review_assignment.user.last_name,

--- a/src/templates/review/review_request_declined.html
+++ b/src/templates/review/review_request_declined.html
@@ -10,8 +10,12 @@
 {% endblock css %}
 
 {% block body %}
-<h3>You have declined this review request.</h3>
-<br>
-<a href="{% url 'login' %}" class="btn btn-primary">Go to Login page</a>
-
+    <h3>Thank you for taking the time to respond to this review request.</h3>
+    {% if request.user.is_authenticated %}
+        <p>You have declined this review request and may now proceed to your dashboard to deal with any other outstanding tasks.</p>
+        <a href="{%  url 'user_dashboard' %}" class="btn btn-primary">Go to Dashboard</a>
+    {%  else %}
+        <p>You have declined this review request and may now proceed to the login page to deal with any other outstanding tasks.</p>
+        <a href="{% url 'login' %}" class="btn btn-primary">Go to Login page</a>
+    {% endif %}
 {% endblock body %}


### PR DESCRIPTION
Trello card: https://trello.com/c/nG74hc30/2649-fixed-unicode-error-when-reviewer-declines-accepts-invitation-to-review

- Changed format strings to unicode to avoid UnicodeEncodeError when there are  non-ascii characters in book titles and reviewer names.
- Made review_request_declined page a bit friendlier.