### PR TITLE
Addressing reviewer email template not displaying

### DIFF
--- a/src/templates/editor/add_editors_editorial_review.html
+++ b/src/templates/editor/add_editors_editorial_review.html
@@ -118,7 +118,7 @@
 					  <hr />
 					  <h3>3. Message to Reviewers</h3>
 					  <p class="small">Add a message that will go out in the email to reviewers.</p>
-					  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text.value }}</textarea>
+					  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text }}</textarea>
 					  <br />
 					  <label class="control-label" for="id_label">Attachment</label>
 					  <p class="small">Please add any additional files here.</p>

--- a/src/templates/editor/add_reviewers.html
+++ b/src/templates/editor/add_reviewers.html
@@ -129,7 +129,7 @@
 					  <hr />
 					  <h3>3. Message to Reviewers</h3>
 					  <p class="small">Add a message that will go out in the email to reviewers.</p>
-					  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text.value }}</textarea>
+					  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text }}</textarea>
 					  <br />
 					  <label class="control-label" for="id_label">Attachment</label>
 					  <p class="small">Please add any additional files here.</p>

--- a/src/templates/editor/assign_copyeditor.html
+++ b/src/templates/editor/assign_copyeditor.html
@@ -75,7 +75,7 @@
   <hr />
   <h3>5. Message to Copyeditor(s)</h3>
   <p class="small">Add a message that will go out in the email to copyeditor(s).</p>
-  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text.value }}</textarea>
+  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text }}</textarea>
   <br />
   <label class="control-label" for="id_label">Attachment</label>
   <p class="small">Please add any additional files here.</p>

--- a/src/templates/editor/assign_indexer.html
+++ b/src/templates/editor/assign_indexer.html
@@ -84,7 +84,7 @@
   <hr />
   <h3>5. Message to Indexer(s)</h3>
   <p class="small">Add a message that will go out in the email to Indexer(s).</p>
-  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text.value }}</textarea>
+  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text }}</textarea>
   <br />
   <label class="control-label" for="id_label">Attachment</label>
   <p class="small">Please add any additional files here.</p>

--- a/src/templates/editor/production/assign_typesetter.html
+++ b/src/templates/editor/production/assign_typesetter.html
@@ -67,7 +67,7 @@
   <hr />
   <h3>4. Message to Typesetter(s)</h3>
   <p class="small">Add a message that will go out in the email to Typesetter(s).</p>
-  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text.value }}</textarea>
+  <textarea class="form-control" rows="10" id="message" name="message">{{ email_text }}</textarea>
   <br />
   <label class="control-label" for="id_label">Attachment</label>
   <p class="small">Please add any additional files here.</p>


### PR DESCRIPTION
Trello card: https://trello.com/c/UbLLe2wC/2650-fixed-non-displaying-reviewer-email-template
- Removed reference to nonexistent 'value' attribute on 'email_text' setting strings (template context objects).