### PR TITLE
Make 'from_email' in notification emails that of the notifier

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -1082,8 +1082,7 @@ def send_proposal_review_request(
         attachment=None,
         access_key=None,
 ):
-    """ Email handler - should be moved to logic! """
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
     base_url = get_setting('base_url', 'general')
     press_name = get_setting('press_name', 'general')
 
@@ -1142,7 +1141,7 @@ def send_proposal_review_reopen_request(
         email_text,
         attachment=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
     base_url = get_setting('base_url', 'general')
     press_name = get_setting('press_name', 'general')
 
@@ -1273,9 +1272,16 @@ def handle_typeset_assignment(
     )
 
 
-def send_decision_ack(book, decision, email_text, url=None, attachment=None):
+def send_decision_ack(
+        request,
+        book,
+        decision,
+        email_text,
+        url=None,
+        attachment=None
+):
     """ Email Handlers - TODO: move to email.py? """
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
 
     if not decision == 'decline':
         decision_full = "Move to " + decision
@@ -1322,6 +1328,7 @@ def send_decision_ack(book, decision, email_text, url=None, attachment=None):
 
 
 def send_editorial_decision_ack(
+        request,
         review_assignment,
         contact,
         decision,
@@ -1329,7 +1336,7 @@ def send_editorial_decision_ack(
         url=None,
         attachment=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
     publishing_committee = get_setting('publishing_committee', 'general')
 
     decision_full = decision
@@ -1411,10 +1418,15 @@ def send_editorial_decision_ack(
             )
 
 
-def send_production_editor_ack(book, editor, email_text, attachment=None):
+def send_production_editor_ack(
+        request,
+        book,
+        editor,
+        email_text,
+        attachment=None
+):
     """ Email Handlers - TODO: move to email.py? """
-    from_email = get_setting('from_address', 'email')
-
+    from_email = request.user.email or get_setting('from_address', 'email')
     context = {'submission': book, 'editor': editor}
     subject = get_setting(
         'production_editor_subject',
@@ -1435,6 +1447,7 @@ def send_production_editor_ack(book, editor, email_text, attachment=None):
 
 
 def send_review_request(
+        request,
         book,
         review_assignment,
         email_text,
@@ -1442,7 +1455,7 @@ def send_review_request(
         attachment=None,
         access_key=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
     base_url = get_setting('base_url', 'general')
     press_name = get_setting('press_name', 'general')
 
@@ -1500,8 +1513,7 @@ def send_proposal_book_editor(
         sender,
         editor_email,
 ):
-    from_email = get_setting('from_address', 'email')
-
+    from_email = request.user.email or get_setting('from_address', 'email')
     if request:
         from_email = "%s <%s>" % (
             request.user.profile.full_name(),
@@ -1527,8 +1539,7 @@ def send_proposal_book_editor(
 
 
 def send_proposal_decline(request, proposal, email_text, sender):
-    from_email = get_setting('from_address', 'email')
-
+    from_email = request.user.email or get_setting('from_address', 'email')
     if request:
         from_email = "%s <%s>" % (
             request.user.profile.full_name(),
@@ -1553,9 +1564,14 @@ def send_proposal_decline(request, proposal, email_text, sender):
     )
 
 
-def send_proposal_update(proposal, email_text, sender, receiver):
-    from_email = get_setting('from_address', 'email')
-
+def send_proposal_update(
+        request,
+        proposal,
+        email_text,
+        sender,
+        receiver
+):
+    from_email = request.user.email or get_setting('from_address', 'email')
     context = {'proposal': proposal, 'sender': sender, 'receiver': receiver}
     subject = get_setting(
         'proposal_update_subject',
@@ -1573,10 +1589,9 @@ def send_proposal_update(proposal, email_text, sender, receiver):
     )
 
 
-def send_proposal_submission_ack(proposal, email_text, owner):
-    from_email = get_setting('from_address', 'email')
+def send_proposal_submission_ack(request, proposal, email_text, owner):
+    from_email = request.user.email or get_setting('from_address', 'email')
     press_name = get_setting('press_name', 'general')
-
     principal_contact_name = get_setting('primary_contact_name', 'general')
 
     context = {
@@ -1602,9 +1617,8 @@ def send_proposal_submission_ack(proposal, email_text, owner):
 
 
 def send_proposal_change_owner_ack(request, proposal, email_text, owner):
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
     press_name = get_setting('press_name', 'general')
-
     principal_contact_name = get_setting('primary_contact_name', 'general')
 
     context = {
@@ -1633,13 +1647,14 @@ def send_proposal_change_owner_ack(request, proposal, email_text, owner):
 
 
 def send_task_decline(assignment, _type, email_text, sender, request):
-    from_email = get_setting('from_address', 'email')
-
-    if request:
+    if request and request.user.is_authenticated:
+        from_email = request.user.email
         from_email = "%s <%s>" % (
             request.user.profile.full_name(),
             from_email,
         )
+    else:
+        from_email = get_setting('from_address', 'email')
 
     context = {'assignment': assignment, 'sender': sender}
     subject = get_setting(
@@ -1667,7 +1682,7 @@ def send_proposal_accept(
         submission, sender,
         attachment=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
 
     if request:
         from_email = "%s <%s>" % (
@@ -1701,7 +1716,7 @@ def send_proposal_accept(
 
 
 def send_proposal_revisions(request, proposal, email_text, sender):
-    from_email = get_setting('from_address', 'email')
+    from_email = request.user.email or get_setting('from_address', 'email')
     press_name = get_setting('press_name', 'general')
 
     if request:
@@ -1734,7 +1749,7 @@ def send_proposal_revisions(request, proposal, email_text, sender):
 
 
 def send_proposal_contract_author_sign_off(proposal, email_text, sender):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),
@@ -1753,7 +1768,7 @@ def send_proposal_contract_author_sign_off(proposal, email_text, sender):
 
 
 def send_invite_typesetter(book, typeset, email_text, sender, attachment):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -2286,6 +2286,7 @@ def proposal_assign_user(request, proposal_id, user_id):
     email_text = get_setting('proposal_submission_ack', 'email')
 
     logic.send_proposal_submission_ack(
+        request,
         _proposal,
         email_text=email_text,
         owner=user,
@@ -3798,7 +3799,9 @@ def contract_manager(request, proposal_id, contract_id=None):
 
                     if not new_contract.author_signed_off:
                         email_text = get_setting(
-                            'proposal_contract_author_sign_off', 'email')
+                            'proposal_contract_author_sign_off',
+                            'email'
+                        )
                         logic.send_proposal_contract_author_sign_off(
                             proposal,
                             email_text,

--- a/src/editor/logic.py
+++ b/src/editor/logic.py
@@ -364,7 +364,7 @@ def send_review_request(
         attachment=None,
         access_key=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
     base_url = get_setting('base_url', 'general')
     press_name = get_setting('press_name', 'general')
 
@@ -420,7 +420,7 @@ def send_editorial_review_request(
         email_text, sender,
         attachment=None
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
     base_url = get_setting('base_url', 'general')
     press_name = get_setting('press_name', 'general')
 
@@ -473,7 +473,7 @@ def send_editorial_review_update(
         sender,
         attachment=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {'book': book, 'review': review_assignment, 'sender': sender}
 
@@ -502,8 +502,7 @@ def send_review_update(
         attachment=None,
 ):
     """ Notify a reviewer that their review due date has been updated. """
-
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {'book': book, 'review': review_assignment, 'sender': sender}
 
@@ -526,7 +525,7 @@ def send_review_update(
 
 
 def send_proposal_decline(proposal, email_text, sender):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {'proposal': proposal, 'sender': sender}
 
@@ -551,7 +550,7 @@ def send_proposal_accept(
         sender,
         attachment=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),
@@ -576,7 +575,7 @@ def send_proposal_accept(
 
 
 def send_proposal_revisions(proposal, email_text, sender):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),
@@ -599,7 +598,7 @@ def send_proposal_revisions(proposal, email_text, sender):
 
 
 def send_author_sign_off(submission, email_text, sender):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),
@@ -629,7 +628,7 @@ def send_copyedit_assignment(
         sender,
         attachment=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),
@@ -661,7 +660,7 @@ def send_author_invite(
         sender,
         attachment=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),
@@ -687,7 +686,7 @@ def send_author_invite(
 
 
 def send_invite_indexer(book, index, email_text, sender, attachment=None):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
     press_name = get_setting('press_name', 'general')
 
     context = {
@@ -715,7 +714,7 @@ def send_invite_indexer(book, index, email_text, sender, attachment=None):
 
 
 def send_invite_typesetter(book, typeset, email_text, sender, attachment=None):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
 
     context = {
         'base_url': get_setting('base_url', 'general'),
@@ -774,7 +773,7 @@ def send_requests_revisions(
         email_text,
         attachments=None,
 ):
-    from_email = get_setting('from_address', 'email')
+    from_email = sender.email or get_setting('from_address', 'email')
     base_url = get_setting('base_url', 'general')
     press_name = get_setting('press_name', 'general')
 

--- a/src/editor/views.py
+++ b/src/editor/views.py
@@ -916,6 +916,7 @@ def editor_decision(request, submission_id, decision):
 
             if 'inform' in request.POST:
                 core_logic.send_decision_ack(
+                    request=request,
                     book=book,
                     decision=decision,
                     email_text=request.POST.get('id_email_text'),
@@ -949,6 +950,7 @@ def editor_decision(request, submission_id, decision):
 
             if 'inform' in request.POST:
                 core_logic.send_decision_ack(
+                    request=request,
                     book=book,
                     decision=decision,
                     email_text=request.POST.get('id_email_text'),
@@ -986,6 +988,7 @@ def editor_decision(request, submission_id, decision):
                 else:
                     url = None
                 core_logic.send_decision_ack(
+                    request=request,
                     book=book,
                     decision=decision,
                     email_text=request.POST.get('id_email_text'),
@@ -1015,6 +1018,7 @@ def editor_decision(request, submission_id, decision):
             book.stage.save()
             if 'inform' in request.POST:
                 core_logic.send_decision_ack(
+                    request=request,
                     book=book,
                     decision=decision,
                     email_text=request.POST.get('id_email_text'),
@@ -1026,6 +1030,7 @@ def editor_decision(request, submission_id, decision):
 
                 for editor in production_editor_list:
                     core_logic.send_production_editor_ack(
+                        request,
                         book,
                         editor,
                         request.POST.get('id_editor_email_text'),

--- a/src/submission/logic.py
+++ b/src/submission/logic.py
@@ -60,8 +60,8 @@ def check_stage(book, check):
         raise PermissionDenied()
 
 
-def send_acknowldgement_email(book, press_editors):
-    from_email = get_setting('from_address', 'email')
+def send_acknowldgement_email(book, press_editors, sender):
+    from_email = sender.email or get_setting('from_address', 'email')
     author_text = get_setting('author_submission_ack', 'email')
     editor_text = get_setting('editor_submission_ack', 'email')
     press_name = get_setting('press_name', 'general')

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -345,7 +345,11 @@ def submission_five(request, book_id):
         press_editors = core_models.User.objects.filter(  # Send ack email.
             profile__roles__slug='press-editor'
         )
-        logic.send_acknowldgement_email(book, press_editors)
+        logic.send_acknowldgement_email(
+            book,
+            press_editors,
+            sender=request.user
+        )
         return redirect(reverse('author_dashboard'))
 
     template = 'submission/submission_five.html'
@@ -534,6 +538,7 @@ def incomplete_proposal(request, proposal_id):
             email_text = get_setting('proposal_submission_ack', 'email')
 
             core_logic.send_proposal_submission_ack(
+                request,
                 proposal,
                 email_text=email_text,
                 owner=request.user,
@@ -662,6 +667,7 @@ def start_proposal(request):
             email_text = get_setting('proposal_submission_ack', 'email')
 
             core_logic.send_proposal_submission_ack(
+                request,
                 proposal,
                 email_text=email_text,
                 owner=request.user,
@@ -892,6 +898,7 @@ def proposal_revisions(request, proposal_id):
                 short_name='Proposal Revisions Submitted'
             )
             core_logic.send_proposal_update(
+                request,
                 proposal,
                 email_text=update_email_text,
                 sender=request.user,
@@ -1124,6 +1131,7 @@ def proposal_view(request, proposal_id):
                 short_name='Proposal Updated',
             )
             core_logic.send_proposal_update(
+                request,
                 proposal,
                 email_text=update_email_text,
                 sender=request.user,


### PR DESCRIPTION
Trello card: https://trello.com/c/AyHpwIuZ/2654-rua-ensure-that-fromemail-in-notification-emails-is-that-of-the-notifier
- Ensured that correct 'from_email' is included in review requests and other notification emails.