### PR TITLE
Add email notification to editors on proposal submission

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -1601,6 +1601,27 @@ def send_proposal_submission_ack(proposal, email_text, owner):
     )
 
 
+def send_new_proposal_notification(sender, proposal, email_text, recipient):
+    from_email = sender.email or get_setting('from_address', 'email')
+    subject = get_setting('new_proposal_notification_subject', 'email_subject')
+
+    context = {
+        'proposal': proposal,
+        'recipient': recipient,
+        'sender': sender,
+    }
+
+    email.send_email(
+        subject,
+        context,
+        from_email,
+        recipient.email,
+        email_text,
+        proposal=proposal,
+        kind='proposal',
+    )
+
+
 def send_proposal_change_owner_ack(request, proposal, email_text, owner):
     from_email = get_setting('from_address', 'email')
     press_name = get_setting('press_name', 'general')

--- a/src/submission/views.py
+++ b/src/submission/views.py
@@ -517,7 +517,19 @@ def incomplete_proposal(request, proposal_id):
                 )
             )
 
+            notification_email_template = get_setting(
+                setting_name='new_proposal_notification',
+                setting_group_name='email',
+            )
+
             for _editor in editors:
+                core_logic.send_new_proposal_notification(
+                    sender=request.user,
+                    proposal=proposal,
+                    email_text=notification_email_template,
+                    recipient=_editor,
+                )
+
                 notification = core_models.Task(
                     assignee=_editor,
                     creator=request.user,
@@ -526,16 +538,20 @@ def incomplete_proposal(request, proposal_id):
                 )
                 notification.save()
 
+
             messages.add_message(
                 request,
                 messages.SUCCESS,
                 'Proposal %s submitted' % proposal.id,
             )
-            email_text = get_setting('proposal_submission_ack', 'email')
+            acknowledgement_email_template = get_setting(
+                'proposal_submission_ack',
+                'email'
+            )
 
             core_logic.send_proposal_submission_ack(
                 proposal,
-                email_text=email_text,
+                email_text=acknowledgement_email_template,
                 owner=request.user,
             )
 


### PR DESCRIPTION
Trello card: https://trello.com/c/hsttnmDV/2655-1-rua-add-email-notification-for-submitted-proposals
- Added email notification to all press editors upon the submission of a book proposal.