### PR TITLE
Updated field name for book series (core.series) in fixture

### DIFF
--- a/src/core/fixtures/test/core.json
+++ b/src/core/fixtures/test/core.json
@@ -1587,7 +1587,7 @@
         "url": "",
         "description": "This is a series.",
         "issn": "1234-123X",
-        "name": "First Time Authors",
+        "title": "First Time Authors",
         "editor": 1
     },
     "model": "core.series",


### PR DESCRIPTION
Changed 'name' to 'title' in series fixture.