### PR TITLE
Fixed problem with emailing editorial reviewer

### DIFF
--- a/src/core/decorators.py
+++ b/src/core/decorators.py
@@ -632,7 +632,7 @@ def is_onetasker(_function):
         elif submission_id:
             book = get_object_or_404(models.Book, pk=submission_id)
             if (
-                request.user in book.onetaskers() or
+                request.user in book.get_onetaskers() or
                 request.user in book.get_all_editors() or
                 book.owner == request.user
             ):

--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -478,7 +478,7 @@ def get_all_user_emails(term):
 
 def get_onetasker_emails(submission_id, term):
     submission = get_object_or_404(models.Book, pk=submission_id)
-    onetaskers = submission.onetaskers()
+    onetaskers = submission.get_onetaskers()
 
     results = []
     for user in onetaskers:

--- a/src/core/settings_dev.py
+++ b/src/core/settings_dev.py
@@ -1,22 +1,206 @@
+import os
+
+from django.contrib import messages
+
+
 # ## GENERIC CONFIG ##
 
 SECRET_KEY = '_%@8*2$*1*i&um4+#a6w(%xqa_19=tfmhu9u-l*7t(a$g(2)wg'
 
-from base_settings import *
 
 DEBUG = True
 
+
+# ## GENERIC CONFIG ##
+
+TECH_EMAIL = 'tech@ubiquitypress.com'
+
+ADMINS = (
+    ('UP Tech', TECH_EMAIL)
+)
 ALLOWED_HOSTS = [
     host.strip() for host in
     os.getenv('DJANGO_ALLOWED_HOSTS', 'localhost').split(',')
 ]
 
-SESSION_COOKIE_NAME = 'rua_cookie'
 
-INSTALLED_APPS += (
-    'test_without_migrations',
-    'debug_toolbar',
+# Username of upadmin
+INTERNAL_USER = 'tech'
+
+
+# Allow static files to be served by uwsgi/gunicorn?
+INCLUDE_STATIC_FILE_URLCONFS = False
+
+SITE_ID = 1
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BOOK_DIR = os.path.join(BASE_DIR, 'files', 'books')
+PROPOSAL_DIR = os.path.join(BASE_DIR, 'files', 'proposals')
+EMAIL_DIR = os.path.join(BASE_DIR, 'files', 'email', 'general')
+
+ROOT_URLCONF = 'core.urls'
+
+WSGI_APPLICATION = 'core.wsgi.application'
+
+LOGIN_REDIRECT_URL = '/user/profile/'
+LOGIN_URL = '/login/'
+
+INSTALLED_APPS = (
+    'flat',
+    'django.contrib.sites',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'core',
+    'submission',
+    'manager',
+    'review',
+    'api',
+    'cron',
+    'revisions',
+    'author',
+    'onetasker',
+    'editor',
+    'swiftsubmit',
+    'editorialreview',
+    'bootstrap3',
+    'django_summernote',
+    'rest_framework',
+    'pymarc',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.github',
+    'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.orcid',
+    'allauth.socialaccount.providers.twitter',
 )
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'core.middleware.Roles',
+    'core.middleware.Version',
+)
+
+MESSAGE_TAGS = {
+    messages.ERROR: 'danger',
+}
+
+AUTHENTICATION_BACKENDS = (
+    # Needed to login by username in Django admin, regardless of `allauth`
+    'django.contrib.auth.backends.ModelBackend',
+    # `allauth` specific authentication methods, such as login by e-mail
+    'allauth.account.auth_backends.AuthenticationBackend',
+)
+
+# Django 1.8 appears confused about where null and blank are required for
+# ManyToMany fields, so we're hiding these warning from the console.
+SILENCED_SYSTEM_CHECKS = (
+    'fields.W340',
+)
+
+SUMMERNOTE_CONFIG = {
+    # Using SummernoteWidget - iframe mode.
+    'iframe': False,  # If False: use SummernoteInplaceWidget - no iframe mode.
+    'airMode': True,  # Using Summernote Air-mode.
+    # Use native HTML tags (`<b>`, `<i>`, ...) instead of style attributes
+    # (Firefox, Chrome only)
+    'styleWithTags': True,
+    # Set text direction : 'left to right' is default.
+    'direction': 'ltr',
+    # Change editor size
+    'width': '100%',
+    'height': '480',
+    # Need authentication while uploading attachments.
+    'attachment_require_authentication': True,
+}
+
+
+# ## CACHE ##
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    }
+}
+
+
+# ## INTERNATIONALISATION ##
+
+LANGUAGE_CODE = 'en-gb'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+DATE_FORMAT = '%d %b, %Y'
+DATETIME_FORMAT = '%d %b, %Y %H:%M'
+
+
+# ## STATIC FILES ##
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'collected-static')
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, 'static-assets'),
+)
+STATIC_URL = '/static/'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(BASE_DIR, 'templates'),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # Already defined Django-related contexts here
+                "django.contrib.auth.context_processors.auth",
+                "django.core.context_processors.debug",
+                "django.core.context_processors.i18n",
+                "django.core.context_processors.media",
+                "django.core.context_processors.static",
+                "django.core.context_processors.tz",
+                "django.contrib.messages.context_processors.messages",
+                "django.core.context_processors.request",
+                "core.context_processors.press",
+                "core.context_processors.task_count",
+                "core.context_processors.review_assignment_count",
+                "core.context_processors.onetasker_task_count",
+                "core.context_processors.author_task_count",
+                "core.context_processors.switch_account",
+                "core.context_processors.roles",
+                "core.context_processors.domain",
+            ],
+        },
+    },
+]
+
+
+# ## VERSION ##
+
+# Updated, committed and tagged using 'bumpversion [major | minor | patch]'
+# run on master branch
+RUA_VERSION = '1.9.8'
+
+
+# ## LOGGING ##
+
+LOGGING = None
+SENTRY_RELEASE = None
+RAVEN_CONFIG = None
 
 # Allow static files to be served by uwsgi/gunicorn?
 INCLUDE_STATIC_FILE_URLCONFS = True
@@ -44,3 +228,5 @@ ORCID_CLIENT_SECRET = 'insert-client-secret'
 ORCID_CLIENT_ID = 'insert-client-id'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+SESSION_COOKIE_NAME = 'rua_cookie'

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -1320,7 +1320,7 @@ class CoreTests(TestCase):
         self.author = models.Author.objects.get(pk=1)
         self.book = models.Book.objects.get(pk=1)
         self.book.save()
-        onetaskers = self.book.onetaskers()
+        onetaskers = self.book.get_onetaskers()
 
         # check that it exists in the database
         self.assertEqual(len(models.Book.objects.all()) == 1, True)


### PR DESCRIPTION
Trello card: https://trello.com/c/Y1gActjN/2819-1-unable-to-send-emails-to-editorial-reviewers

The 'to' field is now automatically populated when attempting to email editorial reviewers.
I've also added some general settings for my dev environment as base_settings.py is gone.