### PR TITLE
Fixed emailing editorial reviewers of proposals and full submissions

### DIFF
--- a/src/core/decorators.py
+++ b/src/core/decorators.py
@@ -612,7 +612,7 @@ def is_onetasker(_function):
         elif submission_id:
             book = get_object_or_404(models.Book, pk=submission_id)
             if (
-                request.user in book.onetaskers() or
+                request.user in book.get_onetaskers() or
                 request.user in book.get_all_editors() or
                 book.owner == request.user
             ):

--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -481,7 +481,7 @@ def get_all_user_emails(term):
 
 def get_onetasker_emails(submission_id, term):
     submission = get_object_or_404(models.Book, pk=submission_id)
-    onetaskers = submission.onetaskers()
+    onetaskers = submission.get_onetaskers()
 
     results = []
     for user in onetaskers:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -11,6 +11,7 @@ from django.utils.encoding import smart_text
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 
+from editorialreview import models as er_models
 from revisions.models import Revision
 from submission.models import Proposal, ProposalReview
 
@@ -1034,30 +1035,16 @@ class Book(models.Model):
     def chapters(self):
         return self.chapter_set.all()
 
-    def onetaskers(self):
-        copyedit_assignments = CopyeditAssignment.objects.filter(book=self)
-        index_assignments = IndexAssignment.objects.filter(book=self)
-        typeset_assignments = TypesetAssignment.objects.filter(book=self)
-        review_assignments = ReviewAssignment.objects.filter(book=self)
-        users = []
-
-        for assignment in copyedit_assignments:
-            user = assignment.copyeditor
-            if user not in users:
-                users.append(user)
-        for assignment in index_assignments:
-            user = assignment.indexer
-            if user not in users:
-                users.append(user)
-        for assignment in typeset_assignments:
-            user = assignment.typesetter
-            if user not in users:
-                users.append(user)
-        for assignment in review_assignments:
-            user = assignment.user
-            if user not in users:
-                users.append(user)
-        return users
+    def get_onetaskers(self):
+        return User.objects.filter(reviewassignment__book=self).union(
+                User.objects.filter(
+                    editorialreview__object_id=self.id,
+                    editorialreview__content_type__model='book'
+                ),
+                User.objects.filter(copyeditor__book=self),
+                User.objects.filter(indexer__book=self),
+                User.objects.filter(typesetter__book=self)
+            )
 
     def get_series_editor(self):
         """Gets the editor of this book's series, if it is part of one.

--- a/src/core/settings_dev.py
+++ b/src/core/settings_dev.py
@@ -1,8 +1,8 @@
 # ## GENERIC CONFIG ##
 
-SECRET_KEY = '_%@8*2$*1*i&um4+#a6w(%xqa_19=tfmhu9u-l*7t(a$g(2)wg'
-
 from .settings import *
+
+SECRET_KEY = '_%@8*2$*1*i&um4+#a6w(%xqa_19=tfmhu9u-l*7t(a$g(2)wg'
 
 DEBUG = True
 
@@ -12,6 +12,8 @@ ALLOWED_HOSTS = [
 ]
 
 SESSION_COOKIE_NAME = 'rua_cookie'
+
+STATIC_URL = '/static/'
 
 MIDDLEWARE += 'debug_toolbar.middleware.DebugToolbarMiddleware',
 INSTALLED_APPS += 'debug_toolbar',
@@ -32,6 +34,10 @@ DATABASES = {
 
 
 # ## EXTERNAL SERVICES ##
+
+RAVEN_CONFIG = None
+SENTRY_RELEASE = None
+SENTRY_DSN = None
 
 ORCID_API_URL = 'http://pub.orcid.org/v1.2_rc7/'
 ORCID_REDIRECT_URI = 'http://localhost:8002/login/orcid/'

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -1469,7 +1469,7 @@ class CoreTests(TestCase):
         self.author = models.Author.objects.get(pk=1)
         self.book = models.Book.objects.get(pk=1)
         self.book.save()
-        onetaskers = self.book.onetaskers()
+        onetaskers = self.book.get_onetaskers()
 
         # check that it exists in the database
         self.assertEqual(len(models.Book.objects.all()) == 1, True)

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -991,7 +991,7 @@ def get_proposal_users(request, proposal_id):
 def email_users(request, group, submission_id=None, user_id=None):
     submission = get_object_or_404(models.Book, pk=submission_id)
     editors = logic.get_editors(submission)
-    onetaskers = submission.onetaskers()
+    onetaskers = submission.get_onetaskers()
     to_value = ""
     sent = False
 
@@ -1086,9 +1086,9 @@ def email_users(request, group, submission_id=None, user_id=None):
                 )
 
         elif group == "onetaskers":
-            user = get_object_or_404(models.User, pk=user_id)
-            if user in onetaskers:
-                to_value = "%s;" % user.email
+            recipient = get_object_or_404(models.User, pk=user_id)
+            if recipient in onetaskers:
+                to_value = "%s;" % recipient.email
             else:
                 messages.add_message(
                     request,
@@ -1107,12 +1107,7 @@ def email_users(request, group, submission_id=None, user_id=None):
 
     group_name = group
 
-    if (
-            not group_name == "editors" and
-            not group_name == "all" and
-            not group_name == "authors" and
-            not group_name == "onetaskers"
-    ):
+    if group_name not in ("editors", "all", "authors", "onetaskers"):
         messages.add_message(
             request,
             messages.ERROR,
@@ -1222,14 +1217,13 @@ def email_general(request, user_id=None):
 @login_required
 def email_users_proposal(request, proposal_id, user_id):
     proposal = get_object_or_404(submission_models.Proposal, pk=proposal_id)
-    proposal_reviews = submission_models.ProposalReview.objects.filter(
-        proposal=proposal,
+    recipient = User.objects.get(pk=user_id)
+    reviewers = User.objects.filter(proposalreview__proposal=proposal).union(
+        User.objects.filter(
+            editorialreview__object_id=proposal.id,
+            editorialreview__content_type__model='proposal',
+        )
     )
-    user = User.objects.get(pk=user_id)
-    list_of_reviewers = []
-
-    for review in proposal_reviews:
-        list_of_reviewers.append(review.user)
 
     to_value = ""
     sent = False
@@ -1294,21 +1288,17 @@ def email_users_proposal(request, proposal_id, user_id):
                 'window.close()</script>'
             )
 
-    if (
-            not proposal.owner == user and
-            not proposal.requestor == user and
-            user not in list_of_reviewers
-    ):
+    if recipient in set(reviewers).union({proposal.owner, proposal.requestor}):
+        to_value = "%s;" % recipient.email
+    else:
         messages.add_message(
             request,
             messages.ERROR,
             "This user is not associated with this proposal"
         )
-    else:
-        to_value = "%s;" % user.email
 
-    if user.profile.is_editor():
-        to_value = "%s;" % user.email
+    if recipient.profile.is_editor():
+        to_value = "%s;" % recipient.email
 
     source = "/email/user/proposal/%s/" % proposal_id
     template = 'core/email.html'


### PR DESCRIPTION
Effectively a duplicate of #607 
Trello card: https://trello.com/c/Y1gActjN/2819-1-unable-to-send-emails-to-editorial-reviewers
