### PR TITLE
reply_to arg on EmailMessage now set to [from_email].

### DIFF
--- a/src/core/email.py
+++ b/src/core/email.py
@@ -56,11 +56,6 @@ def send_email(
     if not type(to) in [list, tuple]:
         to = [to]
 
-    if request:
-        reply_to = request.user.email
-    else:
-        reply_to = get_setting('from_address', 'email')
-
     msg = EmailMessage(
         subject,
         html_content,
@@ -68,7 +63,7 @@ def send_email(
         to,
         bcc=bcc,
         cc=cc,
-        headers={'Reply-To': reply_to}
+        reply_to=[from_email],
     )
 
     if access_key:
@@ -172,11 +167,6 @@ def send_email_multiple(
     if not type(to) in [list, tuple]:
         to = [to]
 
-    if request:
-        reply_to = request.user.email
-    else:
-        reply_to = get_setting('from_address', 'email')
-
     msg = EmailMessage(
         subject,
         html_content,
@@ -184,7 +174,7 @@ def send_email_multiple(
         to,
         bcc=bcc,
         cc=cc,
-        headers={'Reply-To': reply_to}
+        reply_to=[from_email],
     )
 
     if book:


### PR DESCRIPTION
This is a fix for the error Tim reported of erroneous reply-to addresses. 