### PR TITLE
Round 3 testing fix

### DIFF
--- a/src/core/logic.py
+++ b/src/core/logic.py
@@ -1873,12 +1873,10 @@ def get_file_content_dispostion(original_filename):
 
     # Strip non-ascii characters from filename
     # to avoid a bug where an unusable ZIP file is served
+
     return (
-        "attachment; filename={file_name}".format(
-            file_name=original_filename
+        f"attachment; filename={original_filename}".encode(
+            'ascii',
+            errors='replace'
         )
-        #     .encode(
-        #     'ascii',
-        #     errors='ignore'
-        # )
     )


### PR DESCRIPTION
Forcibly removing non-ascii chars from attachment filename in download content disposition. Gunicorn doesn't like serving responses with non-ascii chars in their headers.
Trello card: https://trello.com/c/CvnKw1B1/260-rua-kubernetes-feedback