### PR TITLE
updated Sentry SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ Pillow==5.3.0
 pymarc==3.1.10
 python-docx==0.8.7
 python-memcached==1.59
-raven==6.9.0
 requests==2.20.0
 six==1.11.0
 kombu==4.2.0
+sentry-sdk==0.6.5
+urllib3[secure]==1.24.1

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -1,6 +1,9 @@
 from configparser import ConfigParser
 import os
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 from django.contrib import messages
 
 
@@ -60,7 +63,6 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.google',
     'allauth.socialaccount.providers.orcid',
     'allauth.socialaccount.providers.twitter',
-    'raven.contrib.django.raven_compat',
 )
 
 MIDDLEWARE = (
@@ -209,11 +211,6 @@ LOGGING = {
         },
     },
     'handlers': {
-        'sentry': {
-            'level': 'ERROR',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-            'tags': {'custom-tag': 'x'},
-        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
@@ -231,11 +228,6 @@ LOGGING = {
         },
         'django.db.backends': {
             'level': 'ERROR',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'raven': {
-            'level': 'DEBUG',
             'handlers': ['console'],
             'propagate': False,
         },
@@ -321,15 +313,16 @@ EMAIL_PORT = int(os.getenv('EMAIL_PORT', 587))
 
 SENTRY_DSN = os.getenv(
     'SENTRY_DSN',
-    'https://6f4e629b9384499ea7d6aaa72c820839:'
-    '33c1f6db04914ee7bf7569f1f3e9cb61@sentry.ubiquity.press/5'
+    'https://6f4e629b9384499ea7d6aaa72c820839@sentry.ubiquity.press/5'
+
 )
 config_file = ConfigParser()
 config_file.read('sentry_version.ini')
 SENTRY_RELEASE = config_file.get('sentry', 'version', fallback='ERROR')
 
-RAVEN_CONFIG = {
-    'dsn': SENTRY_DSN,
-    'release': SENTRY_RELEASE,
-    'environment': 'production'
-}
+sentry_sdk.init(
+    dsn=SENTRY_DSN,
+    release=SENTRY_RELEASE,
+    environment=os.getenv('SENTRY_ENV', 'production'),
+    integrations=[DjangoIntegration()]
+)


### PR DESCRIPTION
I've re-created this PR after reverting it. Unfortunately this update broke the CI machine as `settings.py` was loaded and  the `sentry_sdk` module wasn't present. My assumption is that this module needs to be added to the virtual environment used by the CI machine.